### PR TITLE
Add PIP command to the Dev Container file

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -45,7 +45,8 @@
               ]
           }
       }
-  }
+  },
+  "postStartCommand": "pip install -r requirements.txt"
   // Uncomment the next section if you are using WSL2 and SSH with git. This will allow your private key to be
   // accessed by the SSH client within the dev container for connection to the remote repository. Once this
   // section is uncommented reload the dev container. Once the dev container is reloaded re-comment this section.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,6 @@ To run this lab:
 - Open the repository in VSCode on a machine that has docker installed
 - Open VSCode should prompt you to re-open it in the Dev Container.  Do so.
 - If not prompted to open in the Dev Container, in VSCode, press `Ctrl-Shift-P` (for Windows, not sure on mac), and type "**Dev Containers: Reopen in Container**"
-- Once the container is built, and the repo is back on in the container (may take some time)
-  - Open a new terminal window from the menu, "Terminal/New Terminal"
-  - run `pip install -r requirements.txt` 
 - Follow the [Sentiment140 Exercise.docx](./Sentiment140%20Exercise.docx) instructions to download the data set.
 - Open one of the notebooks, and when you attempt to run a cell, from `Python Environments`, choose the `Python 3.11.11` kernel in `/usr/local/bin/python`:
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ To run this lab:
 - Open VSCode should prompt you to re-open it in the Dev Container.  Do so.
 - If not prompted to open in the Dev Container, in VSCode, press `Ctrl-Shift-P` (for Windows, not sure on mac), and type "**Dev Containers: Reopen in Container**"
 - Follow the [Sentiment140 Exercise.docx](./Sentiment140%20Exercise.docx) instructions to download the data set.
+  - You need to extract the zip file that contains the data set (./sentiment140)
 - Open one of the notebooks, and when you attempt to run a cell, from `Python Environments`, choose the `Python 3.11.11` kernel in `/usr/local/bin/python`:
 
   ![Python Environment Selection](./images/PythonEnvironmentSelection.png)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ lightgbm==4.6.0
 numpy==2.2.4
 pandas==2.2.3
 scikit-learn==1.6.1
+wordcloud==1.9.4


### PR DESCRIPTION
This pull request includes updates to the development container configuration and the project setup instructions in the `README.md`. The most important changes are the addition of a post-start command in the dev container configuration and the removal of redundant setup steps from the README.

Also added the zip file with the tweets sentiment.

Updates to development container configuration:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L48-R49): Added a `postStartCommand` to install required Python packages automatically after the container starts.

Updates to project setup instructions:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L8-L10): Removed the step to manually install Python packages in the terminal, as it is now handled by the dev container's post-start command.